### PR TITLE
Check for end of datum more specifically

### DIFF
--- a/nrepl/bencode.py
+++ b/nrepl/bencode.py
@@ -74,7 +74,7 @@ def _read_list(s):
     data = []
     while True:
         datum = _read_datum(s)
-        if not datum:
+        if datum is None:
             break
         data.append(datum)
     return data


### PR DESCRIPTION
This prevents an empty list being treated as the end of a datum.

For example decoding `["foo", []]`, would give `["foo"]` and leave an
'e' on the end of input `s`.
